### PR TITLE
Implement SQL parser and LiteGoDB adapters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
+	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
+github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2 h1:zzrxE1FKn5ryBNl9eKOeqQ58Y/Qpo3Q9QNxKHX5uzzQ=
+github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2/go.mod h1:hzfGeIUDq/j97IG+FhNqkowIyEcD88LrW6fyU3K3WqY=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/multierr v1.9.0 h1:7fIwc/ZtS0q++VgcfqFDxSBZVv/Xo49/SYnDFupUwlI=

--- a/internal/sqlparser/parser.go
+++ b/internal/sqlparser/parser.go
@@ -1,0 +1,162 @@
+package sqlparser
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/rafaelmgr12/litegodb/pkg/litegodb"
+	"github.com/xwb1989/sqlparser"
+)
+
+func ParseAndExecute(query string, db litegodb.DB) (interface{}, error) {
+	stmt, err := sqlparser.Parse(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse query: %w", err)
+	}
+
+	switch stmt := stmt.(type) {
+	case *sqlparser.Insert:
+		return handleInsert(stmt, db)
+	case *sqlparser.Select:
+		return handleSelect(stmt, db)
+	case *sqlparser.Delete:
+		return handleDelete(stmt, db)
+	default:
+		return nil, fmt.Errorf("unsupported SQL statement")
+	}
+}
+
+func handleInsert(stmt *sqlparser.Insert, db litegodb.DB) (interface{}, error) {
+	table := stmt.Table.Name.String()
+	columns := stmt.Columns
+	rows := stmt.Rows.(sqlparser.Values)
+
+	if len(rows) != 1 {
+		return nil, fmt.Errorf("only single row insert is supported")
+	}
+
+	vals := rows[0]
+
+	var key int
+	var value string
+
+	for i, col := range columns {
+		switch col.String() {
+		case "key":
+			keyExpr := vals[i]
+			keyLiteral, ok := keyExpr.(*sqlparser.SQLVal)
+			if !ok {
+				return nil, fmt.Errorf("invalid key value")
+			}
+			keyParsed, err := strconv.Atoi(string(keyLiteral.Val))
+			if err != nil {
+				return nil, fmt.Errorf("invalid key integer value")
+			}
+			key = keyParsed
+		case "value":
+			valueExpr := vals[i]
+			valueLiteral, ok := valueExpr.(*sqlparser.SQLVal)
+			if !ok {
+				return nil, fmt.Errorf("invalid value")
+			}
+			value = string(valueLiteral.Val)
+		default:
+			return nil, fmt.Errorf("unsupported column %s", col.String())
+		}
+	}
+
+	err := db.Put(table, key, value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to put value: %w", err)
+	}
+
+	return "inserted", nil
+}
+
+func handleSelect(stmt *sqlparser.Select, db litegodb.DB) (interface{}, error) {
+	table := stmt.From[0].(*sqlparser.AliasedTableExpr).Expr.(sqlparser.TableName).Name.String()
+
+	var key int
+	foundKey := false
+
+	// Parse WHERE key = X
+	if stmt.Where != nil {
+		compExpr, ok := stmt.Where.Expr.(*sqlparser.ComparisonExpr)
+		if !ok {
+			return nil, fmt.Errorf("unsupported where clause")
+		}
+
+		leftCol := compExpr.Left.(*sqlparser.ColName).Name.String()
+		rightVal := compExpr.Right.(*sqlparser.SQLVal)
+
+		if strings.ToLower(leftCol) != "key" {
+			return nil, fmt.Errorf("only WHERE key = ... supported")
+		}
+
+		k, err := strconv.Atoi(string(rightVal.Val))
+		if err != nil {
+			return nil, fmt.Errorf("invalid key value")
+		}
+
+		key = k
+		foundKey = true
+	}
+
+	if !foundKey {
+		return nil, fmt.Errorf("WHERE clause with key is required")
+	}
+
+	value, found, err := db.Get(table, key)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, fmt.Errorf("key not found")
+	}
+
+	return map[string]interface{}{
+		"key":   key,
+		"value": value,
+	}, nil
+}
+
+func handleDelete(stmt *sqlparser.Delete, db litegodb.DB) (interface{}, error) {
+	table := stmt.TableExprs[0].(*sqlparser.AliasedTableExpr).Expr.(sqlparser.TableName).Name.String()
+
+	var key int
+	foundKey := false
+
+	if stmt.Where != nil {
+		compExpr, ok := stmt.Where.Expr.(*sqlparser.ComparisonExpr)
+		if !ok {
+			return nil, fmt.Errorf("unsupported where clause")
+		}
+
+		leftCol := compExpr.Left.(*sqlparser.ColName).Name.String()
+		rightVal := compExpr.Right.(*sqlparser.SQLVal)
+
+		if strings.ToLower(leftCol) != "key" {
+			return nil, fmt.Errorf("only WHERE key = ... supported")
+		}
+
+		k, err := strconv.Atoi(string(rightVal.Val))
+		if err != nil {
+			return nil, fmt.Errorf("invalid key value")
+		}
+
+		key = k
+		foundKey = true
+	}
+
+	if !foundKey {
+		return nil, fmt.Errorf("WHERE clause with key is required")
+	}
+
+	err := db.Delete(table, key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to delete key: %w", err)
+	}
+
+	return "deleted", nil
+}

--- a/internal/sqlparser/parser_test.go
+++ b/internal/sqlparser/parser_test.go
@@ -1,0 +1,92 @@
+package sqlparser_test
+
+import (
+	"testing"
+
+	"github.com/rafaelmgr12/litegodb/internal/sqlparser"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockDB struct {
+	store map[string]map[int]string
+}
+
+func newMockDB() *mockDB {
+	return &mockDB{store: make(map[string]map[int]string)}
+}
+
+func (m *mockDB) Put(table string, key int, value string) error {
+	if m.store[table] == nil {
+		m.store[table] = make(map[int]string)
+	}
+	m.store[table][key] = value
+	return nil
+}
+
+func (m *mockDB) Get(table string, key int) (string, bool, error) {
+	t, ok := m.store[table]
+	if !ok {
+		return "", false, nil
+	}
+	val, found := t[key]
+	return val, found, nil
+}
+
+func (m *mockDB) Delete(table string, key int) error {
+	t, ok := m.store[table]
+	if !ok {
+		return nil
+	}
+	delete(t, key)
+	return nil
+}
+
+func (m *mockDB) Flush(table string) error                   { return nil }
+func (m *mockDB) CreateTable(table string, degree int) error { return nil }
+func (m *mockDB) DropTable(table string) error               { return nil }
+func (m *mockDB) Load() error                                { return nil }
+func (m *mockDB) Close() error                               { return nil }
+
+func TestParseAndExecute_InsertSelectDelete(t *testing.T) {
+	db := newMockDB()
+
+	// Test INSERT
+	insertQuery := "INSERT INTO users (`key`, `value`) VALUES (1, 'rafael')"
+	res, err := sqlparser.ParseAndExecute(insertQuery, db)
+	assert.NoError(t, err)
+	assert.Equal(t, "inserted", res)
+
+	// Test SELECT
+	selectQuery := "SELECT `key`, `value` FROM users WHERE `key` = 1"
+	res, err = sqlparser.ParseAndExecute(selectQuery, db)
+	assert.NoError(t, err)
+
+	resultMap, ok := res.(map[string]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, 1, resultMap["key"])
+	assert.Equal(t, "rafael", resultMap["value"])
+
+	// Test DELETE
+	deleteQuery := "DELETE FROM users WHERE `key` = 1"
+	res, err = sqlparser.ParseAndExecute(deleteQuery, db)
+	assert.NoError(t, err)
+	assert.Equal(t, "deleted", res)
+
+	// Test SELECT after DELETE (should fail)
+	_, err = sqlparser.ParseAndExecute(selectQuery, db)
+	assert.Error(t, err)
+}
+
+func TestParseAndExecute_InvalidQueries(t *testing.T) {
+	db := newMockDB()
+
+	// Unsupported command
+	badQuery := "UPDATE users SET `value` = 'rafael' WHERE `key` = 1"
+	_, err := sqlparser.ParseAndExecute(badQuery, db)
+	assert.Error(t, err)
+
+	// Bad syntax
+	badSyntax := "SELECT FROM WHERE"
+	_, err = sqlparser.ParseAndExecute(badSyntax, db)
+	assert.Error(t, err)
+}

--- a/pkg/litegodb/litegodb.go
+++ b/pkg/litegodb/litegodb.go
@@ -2,12 +2,6 @@
 // key-value database using a B-Tree as the underlying storage mechanism.
 package litegodb
 
-import (
-	"fmt"
-
-	"github.com/rafaelmgr12/litegodb/internal/storage/kvstore"
-)
-
 // DB defines the interface for interacting with the database.
 // It includes methods for basic CRUD operations, table management, and lifecycle management.
 type DB interface {
@@ -35,59 +29,4 @@ type DB interface {
 
 	// Close closes the database and releases all resources.
 	Close() error
-}
-
-// btreeAdapter is an implementation of the DB interface that uses a B-Tree
-// as the underlying storage mechanism.
-type btreeAdapter struct {
-	kv *kvstore.BTreeKVStore
-}
-
-// Put inserts or updates a key-value pair in the specified table.
-// If the table does not exist, it is automatically created.
-func (b *btreeAdapter) Put(table string, key int, value string) error {
-	if exists := b.kv.IsTableExists(table); !exists {
-		if err := b.kv.CreateTableName(table, 3); err != nil {
-			return fmt.Errorf("failed to create table %s: %w", table, err)
-		}
-	}
-	return b.kv.Put(table, key, value)
-}
-
-// Get retrieves the value associated with the given key in the specified table.
-func (b *btreeAdapter) Get(table string, key int) (string, bool, error) {
-	return b.kv.Get(table, key)
-}
-
-// Delete removes the key-value pair associated with the given key in the specified table.
-func (b *btreeAdapter) Delete(table string, key int) error {
-	return b.kv.Delete(table, key)
-}
-
-// Flush persists all changes in the specified table to disk.
-func (b *btreeAdapter) Flush(table string) error {
-	return b.kv.Flush(table)
-}
-
-// Load reloads the database from disk.
-func (b *btreeAdapter) Load() error {
-	return b.kv.Load()
-}
-
-// Close closes the database and releases all resources.
-func (b *btreeAdapter) Close() error {
-	return b.kv.Close()
-}
-
-// CreateTable creates a new table with the specified degree.
-func (b *btreeAdapter) CreateTable(table string, degree int) error {
-	if _, exists, _ := b.kv.Get(table, 0); exists {
-		return nil
-	}
-	return b.kv.CreateTableName(table, degree)
-}
-
-// DropTable deletes the specified table and all its data.
-func (b *btreeAdapter) DropTable(table string) error {
-	return b.kv.DropTable(table)
 }

--- a/pkg/litegodb/local.go
+++ b/pkg/litegodb/local.go
@@ -1,0 +1,62 @@
+package litegodb
+
+import (
+	"fmt"
+
+	"github.com/rafaelmgr12/litegodb/internal/storage/kvstore"
+)
+
+// btreeAdapter is an implementation of the DB interface that uses a B-Tree
+// as the underlying storage mechanism.
+type btreeAdapter struct {
+	kv *kvstore.BTreeKVStore
+}
+
+// Put inserts or updates a key-value pair in the specified table.
+// If the table does not exist, it is automatically created.
+func (b *btreeAdapter) Put(table string, key int, value string) error {
+	if exists := b.kv.IsTableExists(table); !exists {
+		if err := b.kv.CreateTableName(table, 3); err != nil {
+			return fmt.Errorf("failed to create table %s: %w", table, err)
+		}
+	}
+	return b.kv.Put(table, key, value)
+}
+
+// Get retrieves the value associated with the given key in the specified table.
+func (b *btreeAdapter) Get(table string, key int) (string, bool, error) {
+	return b.kv.Get(table, key)
+}
+
+// Delete removes the key-value pair associated with the given key in the specified table.
+func (b *btreeAdapter) Delete(table string, key int) error {
+	return b.kv.Delete(table, key)
+}
+
+// Flush persists all changes in the specified table to disk.
+func (b *btreeAdapter) Flush(table string) error {
+	return b.kv.Flush(table)
+}
+
+// Load reloads the database from disk.
+func (b *btreeAdapter) Load() error {
+	return b.kv.Load()
+}
+
+// Close closes the database and releases all resources.
+func (b *btreeAdapter) Close() error {
+	return b.kv.Close()
+}
+
+// CreateTable creates a new table with the specified degree.
+func (b *btreeAdapter) CreateTable(table string, degree int) error {
+	if _, exists, _ := b.kv.Get(table, 0); exists {
+		return nil
+	}
+	return b.kv.CreateTableName(table, degree)
+}
+
+// DropTable deletes the specified table and all its data.
+func (b *btreeAdapter) DropTable(table string) error {
+	return b.kv.DropTable(table)
+}

--- a/pkg/litegodb/remote.go
+++ b/pkg/litegodb/remote.go
@@ -1,0 +1,139 @@
+package litegodb
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// remoteAdapter represents a remote connection to a LiteGoDB server.
+type remoteAdapter struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// OpenRemote opens a connection to a remote LiteGoDB server.
+// It returns a DB interface that can be used to interact with the remote database.
+func OpenRemote(baseURL string) (DB, error) {
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	return &remoteAdapter{
+		baseURL:    baseURL,
+		httpClient: client,
+	}, nil
+}
+
+// Put stores a key-value pair in the specified table on the remote LiteGoDB server.
+// It returns an error if the operation fails.
+func (r *remoteAdapter) Put(table string, key int, value string) error {
+	reqBody := map[string]interface{}{
+		"table": table,
+		"key":   key,
+		"value": value,
+	}
+	return r.post("/put", reqBody)
+}
+
+// Get retrieves the value for the specified key from the specified table on the remote LiteGoDB server.
+// It returns the value, a boolean indicating whether the key was found, and an error if the operation fails.
+func (r *remoteAdapter) Get(table string, key int) (string, bool, error) {
+	url := fmt.Sprintf("%s/get?table=%s&key=%d", r.baseURL, table, key)
+	resp, err := r.httpClient.Get(url)
+	if err != nil {
+		return "", false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return "", false, nil
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", false, fmt.Errorf("get failed: %s", resp.Status)
+	}
+
+	var body struct {
+		Value string `json:"value"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", false, err
+	}
+
+	return body.Value, true, nil
+}
+
+// Delete removes the key-value pair with the specified key from the specified table on the remote LiteGoDB server.
+// It returns an error if the operation fails.
+func (r *remoteAdapter) Delete(table string, key int) error {
+	reqBody := map[string]interface{}{
+		"table": table,
+		"key":   key,
+	}
+	return r.post("/delete", reqBody)
+}
+
+// Flush simulates flushing the specified table on the remote LiteGoDB server.
+// In a remote setup, flush might be a no-op or trigger a server-side flush.
+// It returns an error if the operation fails.
+func (r *remoteAdapter) Flush(table string) error {
+	// In a remote setup, flush might be a no-op (or trigger server-side flush).
+	// For now, we'll just simulate it.
+	return nil
+}
+
+// CreateTable simulates creating a table with the specified degree on the remote LiteGoDB server.
+// This function is optional and can be implemented in the future if server-side support is added.
+// It returns an error if the operation fails.
+func (r *remoteAdapter) CreateTable(table string, degree int) error {
+	// Optional future implementation: server-side CreateTable support
+	return nil
+}
+
+// DropTable simulates dropping the specified table on the remote LiteGoDB server.
+// This function is optional and can be implemented in the future if server-side support is added.
+// It returns an error if the operation fails.
+func (r *remoteAdapter) DropTable(table string) error {
+	// Optional future implementation: server-side DropTable support
+	return nil
+}
+
+// Load simulates loading the remote LiteGoDB.
+// This function is not needed in the remote client since the remote server handles persistence.
+// It returns an error if the operation fails.
+func (r *remoteAdapter) Load() error {
+	// Not needed in remote client
+	return nil
+}
+
+// Close simulates closing the connection to the remote LiteGoDB.
+// Since there is no persistent connection, this function does nothing.
+// It returns an error if the operation fails.
+func (r *remoteAdapter) Close() error {
+	// No persistent connection, so nothing to close
+	return nil
+}
+
+// post sends a POST request to the specified path with the provided body to the remote LiteGoDB server.
+// It returns an error if the operation fails.
+func (r *remoteAdapter) post(path string, body map[string]interface{}) error {
+	url := r.baseURL + path
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+
+	resp, err := r.httpClient.Post(url, "application/json", bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("post %s failed: %s", path, resp.Status)
+	}
+
+	return nil
+}

--- a/pkg/litegodb/remote_test.go
+++ b/pkg/litegodb/remote_test.go
@@ -1,0 +1,95 @@
+package litegodb_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rafaelmgr12/litegodb/pkg/litegodb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoteAdapter_PutGetDelete(t *testing.T) {
+	// Fake in-memory database to simulate server-side
+	db := make(map[string]map[int]string)
+
+	// Create a fake HTTP server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/put":
+			var req struct {
+				Table string `json:"table"`
+				Key   int    `json:"key"`
+				Value string `json:"value"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			if db[req.Table] == nil {
+				db[req.Table] = make(map[int]string)
+			}
+			db[req.Table][req.Key] = req.Value
+			w.WriteHeader(http.StatusOK)
+
+		case "/get":
+			table := r.URL.Query().Get("table")
+			keyParam := r.URL.Query().Get("key")
+			var key int
+			_, _ = fmt.Sscanf(keyParam, "%d", &key)
+
+			value, exists := db[table][key]
+			if !exists {
+				http.NotFound(w, r)
+				return
+			}
+
+			resp := map[string]string{"value": value}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+
+		case "/delete":
+			var req struct {
+				Table string `json:"table"`
+				Key   int    `json:"key"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+
+			if db[req.Table] != nil {
+				delete(db[req.Table], req.Key)
+			}
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	// Connect the remote client to the fake server
+	remoteDB, err := litegodb.OpenRemote(server.URL)
+	assert.NoError(t, err)
+
+	// Test PUT
+	err = remoteDB.Put("users", 1, "rafael")
+	assert.NoError(t, err)
+
+	// Test GET (key exists)
+	val, found, err := remoteDB.Get("users", 1)
+	assert.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, "rafael", val)
+
+	// Test GET (key does not exist)
+	_, found, err = remoteDB.Get("users", 999)
+	assert.NoError(t, err)
+	assert.False(t, found)
+
+	// Test DELETE
+	err = remoteDB.Delete("users", 1)
+	assert.NoError(t, err)
+
+	// Test GET after DELETE
+	_, found, err = remoteDB.Get("users", 1)
+	assert.NoError(t, err)
+	assert.False(t, found)
+}

--- a/test/integrations/kvstore_stress_test.go
+++ b/test/integrations/kvstore_stress_test.go
@@ -1,0 +1,83 @@
+package integrations
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/rafaelmgr12/litegodb/internal/storage/disk"
+	"github.com/rafaelmgr12/litegodb/internal/storage/kvstore"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	stressDbFile  = "test_stress.db"
+	stressLogFile = "test_stress.log"
+)
+
+func setupStressKVStore(t *testing.T) (*kvstore.BTreeKVStore, func()) {
+	_ = os.Remove(stressDbFile)
+	_ = os.Remove(stressLogFile)
+
+	diskManager, err := disk.NewFileDiskManager(stressDbFile)
+	require.NoError(t, err)
+
+	kvStore, err := kvstore.NewBTreeKVStore(3, diskManager, stressLogFile)
+	require.NoError(t, err)
+
+	cleanup := func() {
+		kvStore.Close()
+		diskManager.Close()
+		os.Remove(stressDbFile)
+		os.Remove(stressLogFile)
+	}
+
+	return kvStore, cleanup
+}
+
+func TestStressKVStore(t *testing.T) {
+	kvStore, cleanup := setupStressKVStore(t)
+	defer cleanup()
+
+	table := "stress_table"
+	err := kvStore.CreateTableName(table, 3)
+	require.NoError(t, err)
+
+	const numberOfWorkers = 20
+	const numberOfRecords = 10000
+
+	var wg sync.WaitGroup
+	wg.Add(numberOfWorkers)
+
+	for i := 0; i < numberOfWorkers; i++ {
+		go func(workerID int) {
+			defer wg.Done()
+			for j := 0; j < numberOfRecords; j++ {
+				key := workerID*numberOfRecords + j
+				value := fmt.Sprintf("value%d", key)
+				err := kvStore.Put(table, key, value)
+				require.NoError(t, err)
+
+				gotValue, found, err := kvStore.Get(table, key)
+				require.NoError(t, err)
+				require.True(t, found)
+				require.Equal(t, value, gotValue)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Perform read verification after all writes are done
+	for i := 0; i < numberOfWorkers; i++ {
+		for j := 0; j < numberOfRecords; j++ {
+			key := i*numberOfRecords + j
+			expectedValue := fmt.Sprintf("value%d", key)
+			gotValue, found, err := kvStore.Get(table, key)
+			require.NoError(t, err)
+			require.True(t, found)
+			require.Equal(t, expectedValue, gotValue)
+		}
+	}
+}


### PR DESCRIPTION
Introduce an SQL parser supporting INSERT, SELECT, and DELETE operations. Implement BTree and remote adapters for CRUD operations in LiteGoDB. Add stress tests for concurrent read and write operations in the BTreeKVStore.